### PR TITLE
Fix memory issues in upsampling

### DIFF
--- a/callbacks/callbacks.py
+++ b/callbacks/callbacks.py
@@ -107,7 +107,7 @@ def register_callbacks(app):
             except RasterioIOError:
                 return plot_utils.blank_plot("No data available")
             if raster_display == "upsampled":
-                da = da.rio.clip(gdf.geometry.buffer(5))  # 5 degree buffer
+                da = da.rio.clip(gdf.geometry, all_touched=True)
                 da = raster.upsample_raster(da)
             try:
                 da = da.rio.clip(gdf.geometry).sel(date=issue_date)

--- a/callbacks/callbacks.py
+++ b/callbacks/callbacks.py
@@ -107,6 +107,7 @@ def register_callbacks(app):
             except RasterioIOError:
                 return plot_utils.blank_plot("No data available")
             if raster_display == "upsampled":
+                da = da.rio.clip(gdf.geometry.buffer(5))  # 5 degree buffer
                 da = raster.upsample_raster(da)
             try:
                 da = da.rio.clip(gdf.geometry).sel(date=issue_date)


### PR DESCRIPTION
The deployed app hit out of memory issues when trying to upsample the raster, since it was happening against the global COG. Addressed that by clipping with a buffer before upsampling. The 5-degree clip is a bit of a guess and looked reasonable for the bounds I was testing. 

Have validated that this works in the sandbox app here: https://chd-ds-data-validation-sandbox-fwajf4hcarfbgyac.eastus2-01.azurewebsites.net/